### PR TITLE
fix bash condition-testing syntax

### DIFF
--- a/base-notebook/start.sh
+++ b/base-notebook/start.sh
@@ -45,7 +45,7 @@ else
   if [[ ! -z "$NB_GID" && "$NB_GID" != "$(id -g)" ]]; then
       echo 'Container must be run as root to set $NB_GID'
   fi
-  if [ "$GRANT_SUDO" == "1" || "$GRANT_SUDO" == 'yes' ]; then
+  if [[ "$GRANT_SUDO" == "1" || "$GRANT_SUDO" == 'yes' ]]; then
       echo 'Container must be run as root to grant sudo permissions'
   fi
     # Exec the command


### PR DESCRIPTION
`[ "$GRANT_SUDO" == "1" || "$GRANT_SUDO" == 'yes' ]` is wrong ("bash: [: missing `]'"); should be either `[[ "$GRANT_SUDO" == "1" || "$GRANT_SUDO" == 'yes' ]]` or `[ "$GRANT_SUDO" == "1" -a "$GRANT_SUDO" == 'yes' ]`.